### PR TITLE
feat: refresh bus realtime data every 10s via in-job loop

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import time
 from collections import defaultdict
 
 from sqlalchemy import select, delete
@@ -38,5 +40,23 @@ async def execute_script(session):
     await asyncio.gather(*job_list)
     session.close()
 
+
+async def run_loop():
+    # CronJob fires every minute; loop several times within that window to
+    # achieve sub-minute refresh. Tuned via LOOP_ITERATIONS / LOOP_INTERVAL_SECONDS
+    # (default: every 15s, 4 iterations per minute). Pacing keeps the loop inside
+    # the 60s window so consecutive CronJob runs never overlap.
+    iterations = int(os.getenv("LOOP_ITERATIONS", "4"))
+    interval = float(os.getenv("LOOP_INTERVAL_SECONDS", "15"))
+    for i in range(iterations):
+        started_at = time.monotonic()
+        try:
+            await main()
+        except Exception as e:  # noqa: BLE001 - keep loop alive on transient errors
+            print("Bus realtime iteration failed:", e)
+        if i < iterations - 1:
+            await asyncio.sleep(max(0.0, interval - (time.monotonic() - started_at)))
+
+
 if __name__ == '__main__':
-    asyncio.run(main())
+    asyncio.run(run_loop())

--- a/src/models.py
+++ b/src/models.py
@@ -39,7 +39,7 @@ class BusStop(BaseModel):
 
 class BusRouteStop(BaseModel):
     __tablename__ = "bus_route_stop"
-    __table_args__ = (PrimaryKeyConstraint("route_id", "stop_id", name="pk_bus_route_stop"),)
+    __table_args__ = (PrimaryKeyConstraint("route_id", "stop_id", name="unique_bus_route_stop_seq"),)
     route_id: Mapped[int] = mapped_column(ForeignKey("bus_route.route_id"), nullable=False)
     stop_id: Mapped[int] = mapped_column(ForeignKey("bus_stop.stop_id"), nullable=False)
     start_stop_id: Mapped[int] = mapped_column(ForeignKey("bus_stop.stop_id"), nullable=False)


### PR DESCRIPTION
## Summary
- Wrap the one-shot updater in `run_loop()` so a single CronJob invocation refreshes the bus realtime data several times within its minute window, instead of just once.
- Iteration count and interval are configurable via `LOOP_ITERATIONS` / `LOOP_INTERVAL_SECONDS` env vars (code default: every 15s, 4 iterations). The deploy manifest sets these to **6 iterations / 10s** (the GBIS sample key has no daily quota), so realtime data effectively refreshes every 10 seconds.
- Monotonic-clock pacing keeps the whole loop inside the 60s window, so back-to-back CronJob runs never overlap (`concurrencyPolicy: Forbid` on the CronJob as a backstop).

## Also included
- Align the `bus_route_stop` primary key constraint name (`pk_bus_route_stop` -> `unique_bus_route_stop_seq`).

## Notes
- Pairs with the infrastructure change that restricts the CronJob to service hours (05:00-02:00 KST) and sets the loop env vars.