### PR TITLE
fix: Clear stale bus realtime data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ A recurring job that fetches real-time bus arrival information and keeps the HYU
 
 On each run the job:
 
-1. Deletes all existing records from `bus_realtime` (stale data).
-2. Calls the public bus API for each tracked stop.
-3. Inserts fresh arrival predictions into `bus_realtime`.
+1. Calls the public bus API concurrently for each tracked stop.
+2. Replaces the stored snapshot only for stops that returned a successful response.
+3. Clears a stop's stale arrivals when the API successfully returns no active buses.
+4. Preserves the previous snapshot for stops whose request failed or timed out.
 
 ## Architecture
 

--- a/src/main.py
+++ b/src/main.py
@@ -3,42 +3,61 @@ import os
 import time
 from collections import defaultdict
 
-from sqlalchemy import select, delete
+from sqlalchemy import and_, select, delete
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
 
 from models import BusRouteStop, BusRealtime
-from scripts.realtime import get_realtime_data
+from scripts.realtime import BusRealtimeSnapshot, get_realtime_data
 from utils.database import get_db_engine, get_master_db_engine
 
 
 async def main():
     connection = get_db_engine()
-    session_constructor = sessionmaker(bind=connection)
-    session = session_constructor()
-    if session is None:
-        raise RuntimeError("Failed to get db session")
     try:
-        await execute_script(session)
+        await execute_with_connection(connection)
     except OperationalError:
         connection = get_master_db_engine()
-        session_constructor = sessionmaker(bind=connection)
-        session = session_constructor()
+        await execute_with_connection(connection)
+
+
+async def execute_with_connection(connection):
+    session_constructor = sessionmaker(bind=connection)
+    session = session_constructor()
+    try:
         await execute_script(session)
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
 
 
 async def execute_script(session):
     stop_group = defaultdict(list)
     stop_query = select(BusRouteStop.stop_id, BusRouteStop.route_id)
-    session.execute(stop_query)
-    session.execute(delete(BusRealtime))
     for stop_id, route_id in session.execute(stop_query):
         stop_group[stop_id].append(route_id)
-    job_list = []
-    for stop_id, route_id_list in stop_group.items():
-        job_list.append(get_realtime_data(session, stop_id, route_id_list))
-    await asyncio.gather(*job_list)
-    session.close()
+    job_list = [get_realtime_data(stop_id, route_id_list) for stop_id, route_id_list in stop_group.items()]
+    results = await asyncio.gather(*job_list, return_exceptions=True)
+    snapshots: list[BusRealtimeSnapshot] = []
+    for stop_id, result in zip(stop_group.keys(), results):
+        if isinstance(result, BaseException):
+            print(f"Bus realtime fetch failed for stop {stop_id}:", result)
+        else:
+            snapshots.append(result)
+    if stop_group and not snapshots:
+        raise RuntimeError("All bus realtime fetches failed")
+    for snapshot in snapshots:
+        session.execute(delete(BusRealtime).where(and_(
+            BusRealtime.stop_id == snapshot.stop_id,
+            BusRealtime.route_id.in_(snapshot.route_ids),
+        )))
+        if snapshot.arrival_items:
+            insert_statement = insert(BusRealtime).values(snapshot.arrival_items)
+            session.execute(insert_statement)
+    session.commit()
 
 
 async def run_loop():

--- a/src/scripts/realtime.py
+++ b/src/scripts/realtime.py
@@ -1,78 +1,85 @@
-import asyncio
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 from aiohttp import ClientTimeout, ClientSession
 from bs4 import BeautifulSoup, Tag
-from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.orm import Session
-
-from models import BusRealtime
 
 
-async def get_realtime_data(db_session: Session, stop_id: str, route_id_list: list[str]) -> None:
+@dataclass(frozen=True)
+class BusRealtimeSnapshot:
+    stop_id: int
+    route_ids: tuple[int, ...]
+    arrival_items: list[dict]
+
+
+def required_text(parent: Tag, name: str) -> str:
+    item = parent.find(name)
+    if not isinstance(item, Tag):
+        raise RuntimeError(f"Bus realtime API response is missing {name}")
+    return item.text.strip()
+
+
+async def get_realtime_data(stop_id: int, route_id_list: list[int]) -> BusRealtimeSnapshot:
     url = "http://openapi.gbis.go.kr/ws/rest/busarrivalservice/station" \
           f"?serviceKey=1234567890&stationId={stop_id}"
-    arrival_items: list[dict] = []
     timeout = ClientTimeout(total=3.0)
-    try:
-        async with ClientSession(timeout=timeout) as session:
-            async with session.get(url) as response:
-                soup = BeautifulSoup(await response.text(), features="xml")
-                response_item = soup.find("response")
-                if response_item is None:
-                    return
-                message_header = response_item.find("msgHeader")
-                message_body = response_item.find("msgBody")
-                if not isinstance(message_header, Tag) or not isinstance(message_body, Tag):
-                    return
-                query_time_item = message_header.find("queryTime")
-                arrival_list = message_body.find_all("busArrivalList")
-                if query_time_item is None or not arrival_list:
-                    return
-                query_time = query_time_item.text
-                tz = timezone(timedelta(hours=9))
-                for arrival_item in arrival_list:
-                    if int(arrival_item.find("routeId").text) not in route_id_list:
-                        continue
-                    if arrival_item.find("locationNo1").text:
-                        arrival_items.append({
-                            "route_id": int(arrival_item.find("routeId").text),
-                            "stop_id": stop_id,
-                            "arrival_seq": 1,
-                            "remaining_stop_count": int(arrival_item.find("locationNo1").text),
-                            "remaining_seat_count": int(arrival_item.find("remainSeatCnt1").text),
-                            "remaining_time": timedelta(minutes=int(arrival_item.find("predictTime1").text)),
-                            "low_plate": int(arrival_item.find("lowPlate1").text) == 1,
-                            "last_updated_time": datetime.strptime(
-                                query_time, "%Y-%m-%d %H:%M:%S.%f").replace(tzinfo=tz),
-                        })
-                    if arrival_item.find("locationNo2").text:
-                        arrival_items.append({
-                            "route_id": int(arrival_item.find("routeId").text),
-                            "stop_id": stop_id,
-                            "arrival_seq": 2,
-                            "remaining_stop_count": int(arrival_item.find("locationNo2").text),
-                            "remaining_seat_count": int(arrival_item.find("remainSeatCnt2").text),
-                            "remaining_time": timedelta(minutes=int(arrival_item.find("predictTime2").text)),
-                            "low_plate": int(arrival_item.find("lowPlate2").text) == 1,
-                            "last_updated_time": datetime.strptime(
-                                query_time, "%Y-%m-%d %H:%M:%S.%f").replace(tzinfo=tz),
-                        })
-                if arrival_items:
-                    insert_statement = insert(BusRealtime).values(arrival_items)
-                    insert_statement = insert_statement.on_conflict_do_update(
-                        index_elements=["route_id", "stop_id", "arrival_seq"],
-                        set_=dict(
-                            remaining_stop_count=insert_statement.excluded.remaining_stop_count,
-                            remaining_seat_count=insert_statement.excluded.remaining_seat_count,
-                            remaining_time=insert_statement.excluded.remaining_time,
-                            low_plate=insert_statement.excluded.low_plate,
-                            last_updated_time=insert_statement.excluded.last_updated_time,
-                        ),
-                    )
-                    db_session.execute(insert_statement)
-                db_session.commit()
-    except asyncio.exceptions.TimeoutError:
-        print("TimeoutError", url)
-    except AttributeError:
-        print("AttributeError", url)
+    async with ClientSession(timeout=timeout) as session:
+        async with session.get(url) as response:
+            response.raise_for_status()
+            response_text = await response.text()
+    return parse_realtime_data(response_text, stop_id, route_id_list)
+
+
+def parse_realtime_data(response_text: str, stop_id: int, route_id_list: list[int]) -> BusRealtimeSnapshot:
+    arrival_items: list[dict] = []
+    soup = BeautifulSoup(response_text, features="xml")
+    response_item = soup.find("response")
+    if not isinstance(response_item, Tag):
+        raise RuntimeError("Bus realtime API response is missing response")
+    message_header = response_item.find("msgHeader")
+    message_body = response_item.find("msgBody")
+    if not isinstance(message_header, Tag) or not isinstance(message_body, Tag):
+        raise RuntimeError("Bus realtime API response is missing header or body")
+    result_code = required_text(message_header, "resultCode").strip()
+    if result_code not in {"0", "00"}:
+        result_message_item = message_header.find("resultMessage")
+        result_message = result_message_item.text.strip() if isinstance(result_message_item, Tag) else "Unknown error"
+        raise RuntimeError(f"Bus realtime API failed ({result_code}): {result_message}")
+    arrival_list = message_body.find_all("busArrivalList")
+    if not arrival_list:
+        return BusRealtimeSnapshot(stop_id, tuple(route_id_list), [])
+
+    query_time = required_text(message_header, "queryTime")
+    updated_at = datetime.strptime(query_time, "%Y-%m-%d %H:%M:%S.%f").replace(
+        tzinfo=timezone(timedelta(hours=9)),
+    )
+    route_id_set = set(route_id_list)
+    for arrival_item in arrival_list:
+        route_id = int(required_text(arrival_item, "routeId"))
+        if route_id not in route_id_set:
+            continue
+        location_no_1 = required_text(arrival_item, "locationNo1")
+        if location_no_1:
+            arrival_items.append({
+                "route_id": route_id,
+                "stop_id": stop_id,
+                "arrival_seq": 1,
+                "remaining_stop_count": int(location_no_1),
+                "remaining_seat_count": int(required_text(arrival_item, "remainSeatCnt1")),
+                "remaining_time": timedelta(minutes=int(required_text(arrival_item, "predictTime1"))),
+                "low_plate": int(required_text(arrival_item, "lowPlate1")) == 1,
+                "last_updated_time": updated_at,
+            })
+        location_no_2 = required_text(arrival_item, "locationNo2")
+        if location_no_2:
+            arrival_items.append({
+                "route_id": route_id,
+                "stop_id": stop_id,
+                "arrival_seq": 2,
+                "remaining_stop_count": int(location_no_2),
+                "remaining_seat_count": int(required_text(arrival_item, "remainSeatCnt2")),
+                "remaining_time": timedelta(minutes=int(required_text(arrival_item, "predictTime2"))),
+                "low_plate": int(required_text(arrival_item, "lowPlate2")) == 1,
+                "last_updated_time": updated_at,
+            })
+    return BusRealtimeSnapshot(stop_id, tuple(route_id_list), arrival_items)

--- a/tests/test_fetch_realtime_data.py
+++ b/tests/test_fetch_realtime_data.py
@@ -1,14 +1,12 @@
 import asyncio
-from collections import defaultdict
 from datetime import timedelta, datetime
 
 import pytest
-from sqlalchemy import select
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
-from models import BaseModel, BusRealtime, BusRouteStop
-from scripts.realtime import get_realtime_data
+from models import BaseModel, BusRealtime
+from main import execute_script
 from utils.database import get_db_engine
 from tests.insert_bus_information import initialize_bus_data
 
@@ -38,16 +36,7 @@ class TestFetchRealtimeData:
         session_constructor = sessionmaker(bind=connection)
         # Database session check
         session = session_constructor()
-        # Get list to fetch
-        stop_group = defaultdict(list)
-        stop_query = select(BusRouteStop.stop_id, BusRouteStop.route_id)
-        session.execute(stop_query)
-        for stop_id, route_id in session.execute(stop_query):
-            stop_group[stop_id].append(route_id)
-        job_list = []
-        for stop_id, route_id_list in stop_group.items():
-            job_list.append(get_realtime_data(session, stop_id, route_id_list))
-        await asyncio.gather(*job_list)
+        await execute_script(session)
 
         # Check if the data is inserted
         arrival_list = session.query(BusRealtime).all()

--- a/tests/test_realtime_snapshot.py
+++ b/tests/test_realtime_snapshot.py
@@ -1,0 +1,108 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from main import execute_script
+from scripts.realtime import BusRealtimeSnapshot, parse_realtime_data
+
+
+EMPTY_RESPONSE = """
+<response>
+  <msgHeader>
+    <queryTime>2026-07-18 02:00:00.000</queryTime>
+    <resultCode>0</resultCode>
+    <resultMessage>정상적으로 처리되었습니다.</resultMessage>
+  </msgHeader>
+  <msgBody />
+</response>
+"""
+
+ERROR_RESPONSE = """
+<response>
+  <msgHeader>
+    <resultCode>4</resultCode>
+    <resultMessage>잘못된 정류소 ID입니다.</resultMessage>
+  </msgHeader>
+  <msgBody />
+</response>
+"""
+
+ARRIVAL_RESPONSE = """
+<response>
+  <msgHeader>
+    <queryTime>2026-07-18 19:27:36.281</queryTime>
+    <resultCode>0</resultCode>
+    <resultMessage>정상적으로 처리되었습니다.</resultMessage>
+  </msgHeader>
+  <msgBody>
+    <busArrivalList>
+      <locationNo1>9</locationNo1>
+      <locationNo2 />
+      <lowPlate1>0</lowPlate1>
+      <lowPlate2>0</lowPlate2>
+      <predictTime1>14</predictTime1>
+      <predictTime2 />
+      <remainSeatCnt1>41</remainSeatCnt1>
+      <remainSeatCnt2>0</remainSeatCnt2>
+      <routeId>216000061</routeId>
+    </busArrivalList>
+  </msgBody>
+</response>
+"""
+
+
+def test_empty_api_response_is_a_successful_empty_snapshot():
+    snapshot = parse_realtime_data(EMPTY_RESPONSE, 216000379, [216000061, 216000068])
+
+    assert snapshot == BusRealtimeSnapshot(216000379, (216000061, 216000068), [])
+
+
+def test_unsuccessful_api_response_is_not_an_empty_snapshot():
+    with pytest.raises(RuntimeError, match="Bus realtime API failed"):
+        parse_realtime_data(ERROR_RESPONSE, 216000379, [216000061])
+
+
+def test_arrival_response_is_parsed_into_snapshot():
+    snapshot = parse_realtime_data(ARRIVAL_RESPONSE, 216000379, [216000061])
+
+    assert len(snapshot.arrival_items) == 1
+    assert snapshot.arrival_items[0]["route_id"] == 216000061
+    assert snapshot.arrival_items[0]["remaining_stop_count"] == 9
+    assert snapshot.arrival_items[0]["remaining_seat_count"] == 41
+
+
+@pytest.mark.asyncio
+async def test_successful_empty_stop_is_cleared_and_failed_stop_is_preserved():
+    session = MagicMock(spec=Session)
+    session.execute.side_effect = [
+        [(216000379, 216000061), (216000138, 216000068)],
+        MagicMock(),
+    ]
+    empty_snapshot = BusRealtimeSnapshot(216000379, (216000061,), [])
+
+    with patch(
+        "main.get_realtime_data",
+        new=AsyncMock(side_effect=[empty_snapshot, RuntimeError("timeout")]),
+    ):
+        await execute_script(session)
+
+    assert session.execute.call_count == 2
+    delete_statement = session.execute.call_args_list[-1].args[0]
+    params = delete_statement.compile().params
+    assert params["stop_id_1"] == 216000379
+    assert params["route_id_1"] == [216000061]
+    session.commit.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_all_failed_stops_preserve_existing_data():
+    session = MagicMock(spec=Session)
+    session.execute.return_value = [(216000379, 216000061)]
+
+    with patch("main.get_realtime_data", new=AsyncMock(side_effect=RuntimeError("timeout"))):
+        with pytest.raises(RuntimeError, match="All bus realtime fetches failed"):
+            await execute_script(session)
+
+    assert session.execute.call_count == 1
+    session.commit.assert_not_called()


### PR DESCRIPTION
## Summary
- Treat a successful empty GBIS response as an empty snapshot and clear stale arrivals for that stop and its tracked routes.
- Preserve the previous snapshot for stops whose requests fail or time out.
- Fetch stop data concurrently without sharing a SQLAlchemy session, then replace successful snapshots in one database transaction.

## Root cause
The updater deleted the entire `bus_realtime` table before fetching and relied on individual fetch tasks to commit. When every stop returned an empty response, each task returned before committing, so the deletion was rolled back and stale arrivals remained visible in the app. Sharing one session across concurrent tasks could also commit or discard unrelated stop updates.

## Validation
- `python -m pytest -v tests/test_realtime_snapshot.py`
- `python -m flake8 src/ tests/`
- `python -m mypy src/ tests/`
- Parsed a live GBIS response without writing to the database.
