### PR TITLE
chore: Speed up CI workflows

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.14"
         cache: pip
@@ -35,9 +35,9 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.14"
         cache: pip
@@ -76,9 +76,9 @@ jobs:
           - 25432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.14"
         cache: pip

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -3,15 +3,20 @@ on:
   push:
     branches-ignore:
       - main
+concurrency:
+  group: code-check-${{ github.ref_name }}
+  cancel-in-progress: true
 jobs:
   lint:
-    runs-on: [self-hosted, X64, Linux]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
         python-version: "3.14"
+        cache: pip
+        cache-dependency-path: requirements/*.txt
     - name: Install dependencies
       env:
         REQUIREMENTS_FILE: lint
@@ -28,13 +33,15 @@ jobs:
         fi
         python -m flake8 src/ tests
   typecheck:
-    runs-on: [self-hosted, X64, Linux]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
         python-version: "3.14"
+        cache: pip
+        cache-dependency-path: requirements/*.txt
     - name: Install dependencies
       env:
         REQUIREMENTS_FILE: typecheck
@@ -50,7 +57,7 @@ jobs:
         fi
         python -m mypy --no-color-output src/ tests
   test:
-    runs-on: [self-hosted, X64, Linux]
+    runs-on: ubuntu-latest
     env:
       POSTGRES_ID: test
       POSTGRES_PASSWORD: test
@@ -74,6 +81,8 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.14"
+        cache: pip
+        cache-dependency-path: requirements/*.txt
     - name: Install dependencies
       env:
         REQUIREMENTS_FILE: test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,11 +12,11 @@ jobs:
     env:
       IMAGE_NAME: localhost:5000/hyuabot-bus-realtime-updater:latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Docker Build Environment
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
     - name: Build and push
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Dockerfile


### PR DESCRIPTION
## Summary

- Run Python lint, type-check, and test jobs on parallel GitHub-hosted Linux runners instead of the single shared X64 runner.
- Cache downloaded Python packages using the repository dependency files.
- Cancel stale checks for the same branch so newer revisions are not blocked behind obsolete work.
- Upgrade code-check and deployment actions to Node.js 24-based releases.

## Validation

- Parsed all workflow files as YAML.
- Validated the modified workflow with actionlint.
- Confirmed every referenced action uses the Node.js 24 runtime.
